### PR TITLE
Add .readthedocs.yml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,7 @@
+# https://docs.readthedocs.io/en/stable/config-file/v2.html
+version: 2
+build:
+  tools:
+    python: "3.11"
+sphinx:
+   configuration: docs/conf.py


### PR DESCRIPTION
Read the Docs is [requiring config files](https://blog.readthedocs.com/migrate-configuration-v2/).

Think this will work, @Changaco? :)

